### PR TITLE
fixed invalid composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name" : "ZendServerDeploymentHelper",
+  "name" : "zend-pattern/ZendServerDeploymentHelper",
   "require" : {
     "zendframework/zendframework" : "=2.4.8",
     "phpunit/phpunit" : "=3.7.32",


### PR DESCRIPTION
According to https://getcomposer.org/doc/04-schema.md#name the value of the name property in composer.json must match a valid pattern.